### PR TITLE
ignoring directory created during local test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ dmypy.json
 .pyre/
 
 .idea/
+
+.DS_Store
+
+# Local testing
+ecosystem/resources/cloned_repo_directory/


### PR DESCRIPTION
A directory is created when tests are run locally. Adding it to the `.gitignore`