### PR TITLE
Description and order of the tiers in a json

### DIFF
--- a/ecosystem/resources/tiers.json
+++ b/ecosystem/resources/tiers.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Main",
+    "description": "The Qiskit immediate family"
+  },
+  {
+    "name": "Extensions",
+    "description": "IBM Quantum supported Qiskit extensions"
+  },
+    {
+    "name": "Partners",
+    "description": "Select group of providers and vendors that are verified for Qiskit compatibility and validity"
+  },
+    {
+    "name": "Prototypes",
+    "description": "Software packages supporting cutting-edge research on quantum algorithms and applications"
+  },
+  {
+    "name": "Community",
+    "description": "Supported by the Qiskit community"
+  }
+
+]

--- a/ecosystem/resources/tiers.json
+++ b/ecosystem/resources/tiers.json
@@ -17,7 +17,7 @@
   },
   {
     "name": "Community",
-    "description": "Supported by the Qiskit community"
+    "description": "Software packages supported by the Qiskit community, not maintained by IBM Quantum"
   }
 
 ]

--- a/ecosystem/resources/tiers.json
+++ b/ecosystem/resources/tiers.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Main",
-    "description": "The Qiskit immediate family"
+    "description": "The main Qiskit packages maintained by IBM Quantum"
   },
   {
     "name": "Extensions",

--- a/ecosystem/resources/tiers.json
+++ b/ecosystem/resources/tiers.json
@@ -9,7 +9,7 @@
   },
     {
     "name": "Partners",
-    "description": "Select group of providers and vendors that are verified for Qiskit compatibility and validity"
+    "description": "A select group of providers and vendors that are verified for Qiskit compatibility and validity"
   },
     {
     "name": "Prototypes",


### PR DESCRIPTION
Adding `ecosystem/resources/tiers.json` to describe each tier. Order in the list is relevant.

Fixes #174