### PR TITLE
normalize labels: ml and space in machine learning

### DIFF
--- a/ecosystem/resources/members.json
+++ b/ecosystem/resources/members.json
@@ -48,7 +48,7 @@
             "description": "The Machine Learning package contains sample datasets and quantum ML algorithms.",
             "labels": [
                 "algorithms",
-                "ml"
+                "machine learning"
             ],
             "licence": "Apache 2.0",
             "name": "qiskit-machine-learning",
@@ -3326,8 +3326,7 @@
             "affiliations": null,
             "labels": [
                 "paper implementation",
-                "machine",
-                "learning",
+                "machine learning",
                 "finance"
             ],
             "created_at": 1669126844.414968,
@@ -4265,7 +4264,7 @@
             "affiliations": null,
             "labels": [
                 "prototype",
-                "ml"
+                "machine learning"
             ],
             "created_at": 1645480343.964777,
             "updated_at": 1645480343.964777,


### PR DESCRIPTION
`machine learning` is another label affected by #272. Additionally, some projects use `ml`. 