### PR TITLE
Move qiskit-ionq to community tier

### DIFF
--- a/ecosystem/resources/members.json
+++ b/ecosystem/resources/members.json
@@ -4922,7 +4922,7 @@
             ],
             "styles_results": [],
             "coverages_results": [],
-            "tier": "Extensions",
+            "tier": "Community",
             "configuration": {
                 "language": {
                     "name": "python",


### PR DESCRIPTION
The `qiskit-ionq` package was incorrectly tagged as being in the "Extensions" tier. This moves it to "Community".