### PR TITLE
Support for multi-paragraph description

### DIFF
--- a/ecosystem/utils/submission_parser.py
+++ b/ecosystem/utils/submission_parser.py
@@ -8,10 +8,13 @@ from ecosystem.models.repository import Repository
 def _clean_section(section: str) -> {str: str}:
     """For a section, return a tuple with a title and "clean section".
     A clean section is without empty lines and strip spaces"""
-    paragraphs = section.split('\n\n')
-    section = ('\n').join([paragraph.strip() for paragraph in paragraphs[1:] if paragraph])
+    paragraphs = section.split("\n\n")
+    section = ("\n").join(
+        [paragraph.strip() for paragraph in paragraphs[1:] if paragraph]
+    )
     title = paragraphs[0].strip()
     return (title, section)
+
 
 def parse_submission_issue(body_of_issue: str) -> Repository:
     """Parse issue body.
@@ -24,19 +27,21 @@ def parse_submission_issue(body_of_issue: str) -> Repository:
 
     issue_formatted = mdformat.text(body_of_issue)
 
-    sections = defaultdict(None, [_clean_section(s) for s in issue_formatted.split('### ')[1:]])
+    sections = defaultdict(
+        None, [_clean_section(s) for s in issue_formatted.split("### ")[1:]]
+    )
 
-    repo_name = sections['Github repo'].split("/")[-1]
+    repo_name = sections["Github repo"].split("/")[-1]
 
     name = repo_name
-    url = sections['Github repo']
-    description = sections['Description']
-    contact_info = sections['Email']
-    alternatives = sections['Alternatives']
-    licence = sections['License']
-    affiliations = sections['Affiliations']
+    url = sections["Github repo"]
+    description = sections["Description"]
+    contact_info = sections["Email"]
+    alternatives = sections["Alternatives"]
+    licence = sections["License"]
+    affiliations = sections["Affiliations"]
 
-    labels = [l.strip() for l in sections['Tags'].split(",")]
+    labels = [l.strip() for l in sections["Tags"].split(",")]
 
     return Repository(
         name,

--- a/ecosystem/utils/submission_parser.py
+++ b/ecosystem/utils/submission_parser.py
@@ -7,9 +7,9 @@ from ecosystem.models.repository import Repository
 
 def _clean_section(section: str) -> {str: str}:
     """For a section, return a tuple with a title and "clean section".
-    A clean section is without empty lines and strip spaces"""
-    paragraphs = section.split("\n\n")
-    section = ("\n").join(
+    A clean section is without new lines and strip spaces"""
+    paragraphs = section.split("\n")
+    section = (" ").join(
         [paragraph.strip() for paragraph in paragraphs[1:] if paragraph]
     )
     title = paragraphs[0].strip()

--- a/ecosystem/utils/submission_parser.py
+++ b/ecosystem/utils/submission_parser.py
@@ -1,9 +1,17 @@
 """Parser for issue submission."""
-import re
+from collections import defaultdict
 import mdformat
 
 from ecosystem.models.repository import Repository
 
+
+def _clean_section(section: str) -> {str: str}:
+    """For a section, return a tuple with a title and "clean section".
+    A clean section is without empty lines and strip spaces"""
+    paragraphs = section.split('\n\n')
+    section = ('\n').join([paragraph.strip() for paragraph in paragraphs[1:] if paragraph])
+    title = paragraphs[0].strip()
+    return (title, section)
 
 def parse_submission_issue(body_of_issue: str) -> Repository:
     """Parse issue body.
@@ -16,19 +24,19 @@ def parse_submission_issue(body_of_issue: str) -> Repository:
 
     issue_formatted = mdformat.text(body_of_issue)
 
-    parse = re.findall(r"^([\s\S]*?)(?:\n{2,}|\Z)", issue_formatted, re.M)
+    sections = defaultdict(None, [_clean_section(s) for s in issue_formatted.split('### ')[1:]])
 
-    repo_name = parse[1].split("/")
+    repo_name = sections['Github repo'].split("/")[-1]
 
-    name = repo_name[-1]
-    url = parse[1]
-    description = parse[3]
-    contact_info = parse[5]
-    alternatives = parse[7]
-    licence = parse[9]
-    affiliations = parse[11]
+    name = repo_name
+    url = sections['Github repo']
+    description = sections['Description']
+    contact_info = sections['Email']
+    alternatives = sections['Alternatives']
+    licence = sections['License']
+    affiliations = sections['Affiliations']
 
-    labels = [l.strip() for l in parse[13].split(",")]
+    labels = [l.strip() for l in sections['Tags'].split(",")]
 
     return Repository(
         name,

--- a/tests/resources/issue.md
+++ b/tests/resources/issue.md
@@ -6,6 +6,10 @@ http://github.com/awesome/awesome
 
 An awesome repo for awesome project
 
+multiple
+
+paragraphs
+
 ### Email
 
 toto@gege.com

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -99,7 +99,7 @@ class TestManager(TestCase):
         )
         self.assertEqual(
             output_value[2],
-            "::set-output name=SUBMISSION_DESCRIPTION::An awesome repo for awesome project",
+            "::set-output name=SUBMISSION_DESCRIPTION::An awesome repo for awesome project multiple paragraphs",
         )
         self.assertEqual(
             output_value[3], "::set-output name=SUBMISSION_LICENCE::Apache License 2.0"

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -99,7 +99,8 @@ class TestManager(TestCase):
         )
         self.assertEqual(
             output_value[2],
-            "::set-output name=SUBMISSION_DESCRIPTION::An awesome repo for awesome project multiple paragraphs",
+            "::set-output name=SUBMISSION_DESCRIPTION::An awesome repo for awesome project multiple"
+            " paragraphs",
         )
         self.assertEqual(
             output_value[3], "::set-output name=SUBMISSION_LICENCE::Apache License 2.0"

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -31,7 +31,7 @@ class TestUtils(TestCase):
         self.assertEqual(parsed_result.url, "http://github.com/awesome/awesome")
         self.assertEqual(
             parsed_result.description,
-            "An awesome repo for awesome project\nmultiple\nparagraphs",
+            "An awesome repo for awesome project multiple paragraphs",
         )
         self.assertEqual(parsed_result.contact_info, "toto@gege.com")
         self.assertEqual(parsed_result.alternatives, "tititata")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -30,7 +30,7 @@ class TestUtils(TestCase):
         self.assertEqual(parsed_result.name, "awesome")
         self.assertEqual(parsed_result.url, "http://github.com/awesome/awesome")
         self.assertEqual(
-            parsed_result.description, "An awesome repo for awesome project"
+            parsed_result.description, "An awesome repo for awesome project\nmultiple\nparagraphs"
         )
         self.assertEqual(parsed_result.contact_info, "toto@gege.com")
         self.assertEqual(parsed_result.alternatives, "tititata")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -30,7 +30,8 @@ class TestUtils(TestCase):
         self.assertEqual(parsed_result.name, "awesome")
         self.assertEqual(parsed_result.url, "http://github.com/awesome/awesome")
         self.assertEqual(
-            parsed_result.description, "An awesome repo for awesome project\nmultiple\nparagraphs"
+            parsed_result.description,
+            "An awesome repo for awesome project\nmultiple\nparagraphs",
         )
         self.assertEqual(parsed_result.contact_info, "toto@gege.com")
         self.assertEqual(parsed_result.alternatives, "tititata")


### PR DESCRIPTION

### Summary

When a description has multiple paragraphs, `submission_parser.py` was braking. For example: https://github.com/qiskit-community/ecosystem/issues/322#issuecomment-1441533404

### Details and comments

The submission parser is now slightly stronger and supports changes in the submission issue template. Now splits based on sections instead of empty lines, allowing for multi-line sections.
