### PR TITLE
Quote injection in parse-issue

### DIFF
--- a/.github/workflows/ecosystem-submission.yml
+++ b/.github/workflows/ecosystem-submission.yml
@@ -48,8 +48,9 @@ jobs:
     # workflow
     - name: Parse submission
       id: parse-issue
-      run: |
-        python manager.py parser_issue --body="${{ github.event.issue.body }}"
+      env:
+        ISSUE_BODY: ${{ github.event.issue.body }}
+      run: python manager.py parser_issue --body=$ISSUE_BODY
     - name: Tests stable check
       id: stable
       uses: ./.github/actions/run-tests


### PR DESCRIPTION
There is an issue in the action `parse-issue` when `github.event.issue.body` contains double quotes.

```
python manager.py parser_issue --body="${{ github.event.issue.body }}"
```

Following the advice in https://securitylab.github.com/research/github-actions-untrusted-input/ , the body is set as env.