### PR TITLE
[DEPRECIATION] Can't set-output to share information between steps in CI

### DIFF
--- a/.github/workflows/ecosystem-project-check.yml
+++ b/.github/workflows/ecosystem-project-check.yml
@@ -48,14 +48,14 @@ jobs:
     # check if any of the tests failed
     - name: Check return
       run: |
-        echo "PASS_LOG=True" >> $GITHUB_ENV
+        echo "PASS_LOG=True" >> "$GITHUB_OUTPUT"
 
         declare -a return_list=( \
           "${{ steps.test_step.outputs.result }}" \
         )
         for i in "${return_list[@]}"; do
           if [[ "${i}" != *"True"* ]]; then
-            echo "PASS_LOG=False" >> $GITHUB_ENV
+            echo "PASS_LOG=False" >> "$GITHUB_OUTPUT"
           fi
         done
 

--- a/.github/workflows/ecosystem-submission.yml
+++ b/.github/workflows/ecosystem-submission.yml
@@ -81,7 +81,7 @@ jobs:
     # Check result, update issue and create MR
     - name: Check return
       run: |
-        echo "PASS_LOG=True" >> $GITHUB_ENV
+        echo "PASS_LOG=True" >> "$GITHUB_OUTPUT"
 
         declare -a return_list=( \
           "${{ steps.stable.outputs.result }}" \
@@ -90,7 +90,7 @@ jobs:
         )
         for i in "${return_list[@]}"; do
           if [[ "${i}" != *"True"* ]]; then
-            echo "PASS_LOG=False" >> $GITHUB_ENV
+            echo "PASS_LOG=False" >> "$GITHUB_OUTPUT"
           fi
         done
 

--- a/ecosystem/utils/utils.py
+++ b/ecosystem/utils/utils.py
@@ -1,4 +1,5 @@
 """Logging module."""
+import os
 import logging
 from typing import Tuple, List, Union
 import coloredlogs
@@ -37,4 +38,5 @@ def set_actions_output(outputs: List[Tuple[str, Union[str, bool, float, int]]]) 
     """
     for name, value in outputs:
         logger.info("Setting output variable %s: %s", name, value)
-        print("::set-output name={name}::{value}".format(name=name, value=value))
+        with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
+            print("name={name}::{value}".format(name=name, value=value), file=fh)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Replace GITHUB_ENV with GITHUB_OUTPUT new env variable.


### Details and comments
- [x] Update wf
- [x] Update utils.py

---
Closes #406 