### PR TITLE
Move prototype-qrao to community from extensions

### DIFF
--- a/ecosystem/resources/members/prototype-qrao.toml
+++ b/ecosystem/resources/members/prototype-qrao.toml
@@ -9,7 +9,7 @@ created_at = 1678827878.909912
 updated_at = 1678827878.909913
 styles_results = []
 coverages_results = []
-tier = "Extensions"
+tier = "Community"
 skip_tests = false
 stars = 27
 [[tests_results]]


### PR DESCRIPTION
I think prototype-qrao was tagged as Extension where I think it should had been Community. @blakejohnson ?

See https://github.com/qiskit-community/prototype-qrao for context.
