### PR TITLE
fix typo for test function in manager.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,11 @@ pip install -r requirements-dev.txt
 
 # Running the tests
 1. To run tests against the stable version of qiskit  <br/>
-<code> python manager.py stable_compatibility_tests <url_of_the github_repository></code>
+<code> python manager.py python_stable_tests <url_of_the github_repository> --python_version=py39 --run_name="stable"</code>
 2. To run tests against the dev version of qiskit  <br/>
-<code> python manager.py  dev_compatibility_tests  <url_of_the github_repository></code>
+<code> python manager.py  python_dev_tests  <url_of_the github_repository> --python_version=py39 --run_name="dev"</code>
 3. To run tests within repository  <br/>
-<code> python manager.py python_standard_tests <url_of_the github_repository></code>
+<code> python manager.py python_standard_tests <url_of_the github_repository> --python_version=py39 --run_name="standard"</code>
 
 # Performing style checks
 - Run for style checks 

--- a/manager.py
+++ b/manager.py
@@ -4,17 +4,17 @@ Available commands:
 
 1. Run tests within repository.
 ```shell
-python manager.py standard_tests https://github.com/<ACCOUNT>/<REPOSITORY_NAME> --tox_python=<py36,py37,py38,py39>
+python manager.py python_standard_tests https://github.com/<ACCOUNT>/<REPOSITORY_NAME> --tox_python=<py36,py37,py38,py39>
 ```
 
 2. Run tests against stable version of Qiskit.
 ```shell
-python manager.py stable_compatibility_tests https://github.com/<ACCOUNT>/<REPOSITORY_NAME> --tox_python=<py36,py37,py38,py39>
+python manager.py python_stable_tests https://github.com/<ACCOUNT>/<REPOSITORY_NAME> --tox_python=<py36,py37,py38,py39>
 ```
 
 3. Run tests against dev version of Qiskit.
 ```shell
-python manager.py dev_compatibility_tests https://github.com/<ACCOUNT>/<REPOSITORY_NAME> --tox_python=<py36,py37,py38,py39>
+python manager.py python_dev_tests https://github.com/<ACCOUNT>/<REPOSITORY_NAME> --tox_python=<py36,py37,py38,py39>
 ```
 
 4. Get parse issue.


### PR DESCRIPTION
- [X] I have read the CONTRIBUTING document.

### Summary

I tried running tests locally and found wrong command.

### Details and comments

* stable_compatibility_tests -> python_stable_tests

* dev_compatibility_tests -> python_dev_tests

* standard_tests ->  python_standard_tests

and added python_version, run_name required argument.